### PR TITLE
added possibility to use DoNotCreateFeatureMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ public class Owner {
     private String email;
     @GenerateMatcher
     private String uid;
+    @DoNotGenerateMatcher // excludes field from generation of matchers for class level @GenerateMatcher annotation
+    private String name;
 
     public String getEmail() {
         return email;

--- a/feature-matcher-generator-e2e-test/src/main/java/ru/yandex/qatools/proc/test/Lord.java
+++ b/feature-matcher-generator-e2e-test/src/main/java/ru/yandex/qatools/proc/test/Lord.java
@@ -1,5 +1,6 @@
 package ru.yandex.qatools.proc.test;
 
+import ru.yandex.qatools.processors.matcher.gen.annotations.DoNotGenerateMatcher;
 import ru.yandex.qatools.processors.matcher.gen.annotations.GenerateMatcher;
 
 /**
@@ -8,7 +9,7 @@ import ru.yandex.qatools.processors.matcher.gen.annotations.GenerateMatcher;
 
 @GenerateMatcher
 public class Lord {
-
+    @DoNotGenerateMatcher
     private String name;
     private Integer slavesCount;
 

--- a/feature-matcher-generator-e2e-test/src/main/java/ru/yandex/qatools/proc/test/Lord.java
+++ b/feature-matcher-generator-e2e-test/src/main/java/ru/yandex/qatools/proc/test/Lord.java
@@ -9,9 +9,15 @@ import ru.yandex.qatools.processors.matcher.gen.annotations.GenerateMatcher;
 
 @GenerateMatcher
 public class Lord {
-    @DoNotGenerateMatcher
     private String name;
     private Integer slavesCount;
+
+    @DoNotGenerateMatcher
+    private String fullName;
+
+    @GenerateMatcher
+    @DoNotGenerateMatcher
+    private Integer age;
 
 
     public String getName() {
@@ -22,4 +28,11 @@ public class Lord {
         return slavesCount;
     }
 
+    public Object getFullName() {
+        return fullName;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
 }

--- a/feature-matcher-generator-e2e-test/src/test/java/ru/yandex/qatools/proc/test/LordTest.java
+++ b/feature-matcher-generator-e2e-test/src/test/java/ru/yandex/qatools/proc/test/LordTest.java
@@ -7,9 +7,9 @@ import java.lang.reflect.Method;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 
 /**
  * @author Vladislav Bauer
@@ -25,10 +25,9 @@ public class LordTest {
     @Test
     public void shouldFindMatchersForAllField() throws Exception {
         assertThat(
-                Stream.of(LordMatchers.class.getDeclaredMethods()).map(Method::getName).collect(toList()), 
-                hasItems("withName", "withSlavesCount")
+                Stream.of(LordMatchers.class.getDeclaredMethods()).map(Method::getName).collect(toList()),
+                hasItem("withSlavesCount")
         );
-        assertThat(LordMatchers.class.getDeclaredMethod("withName", Matcher.class), notNullValue());
         assertThat(LordMatchers.class.getDeclaredMethod("withSlavesCount", Matcher.class), notNullValue());
     }
 

--- a/feature-matcher-generator-e2e-test/src/test/java/ru/yandex/qatools/proc/test/LordTest.java
+++ b/feature-matcher-generator-e2e-test/src/test/java/ru/yandex/qatools/proc/test/LordTest.java
@@ -7,9 +7,11 @@ import java.lang.reflect.Method;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.IsNot.not;
 
 /**
  * @author Vladislav Bauer
@@ -25,9 +27,10 @@ public class LordTest {
     @Test
     public void shouldFindMatchersForAllField() throws Exception {
         assertThat(
-                Stream.of(LordMatchers.class.getDeclaredMethods()).map(Method::getName).collect(toList()),
-                hasItem("withSlavesCount")
+                Stream.of(LordMatchers.class.getDeclaredMethods()).map(Method::getName).collect(toList()), 
+                allOf(hasItems("withName", "withSlavesCount"), not(hasItems("withFullName", "withAge")))
         );
+        assertThat(LordMatchers.class.getDeclaredMethod("withName", Matcher.class), notNullValue());
         assertThat(LordMatchers.class.getDeclaredMethod("withSlavesCount", Matcher.class), notNullValue());
     }
 

--- a/feature-matcher-generator/src/main/java/ru/yandex/qatools/processors/matcher/gen/processing/FillMapWithFieldsProcess.java
+++ b/feature-matcher-generator/src/main/java/ru/yandex/qatools/processors/matcher/gen/processing/FillMapWithFieldsProcess.java
@@ -1,5 +1,6 @@
 package ru.yandex.qatools.processors.matcher.gen.processing;
 
+import ru.yandex.qatools.processors.matcher.gen.annotations.DoNotGenerateMatcher;
 import ru.yandex.qatools.processors.matcher.gen.bean.ClassDescription;
 import ru.yandex.qatools.processors.matcher.gen.util.helpers.GeneratorHelper;
 
@@ -45,7 +46,7 @@ public class FillMapWithFieldsProcess implements Consumer<Element> {
     public void accept(Element elem) {
         ElementKind elemKind = elem.getKind();
 
-        if (elemKind == ElementKind.FIELD) {
+        if (elemKind == ElementKind.FIELD && elem.getAnnotation(DoNotGenerateMatcher.class) == null) {
             TypeElement classElement = (TypeElement) elem.getEnclosingElement();
             PackageElement packageElement = (PackageElement) classElement.getEnclosingElement();
 


### PR DESCRIPTION
Added possibility to use DoNotCreateFeatureMatcher annotations for fields. I found this annotation but it didn't work. Sometimes it necessary to avoid creation of matcher for ex. for constants.