### PR TITLE
Also find getters that's capitalization does not match the field name

### DIFF
--- a/feature-matcher-generator-e2e-test/src/main/java/ru/yandex/qatools/proc/test/Capitalization.java
+++ b/feature-matcher-generator-e2e-test/src/main/java/ru/yandex/qatools/proc/test/Capitalization.java
@@ -1,0 +1,12 @@
+package ru.yandex.qatools.proc.test;
+
+import ru.yandex.qatools.processors.matcher.gen.annotations.GenerateMatcher;
+
+@GenerateMatcher
+public class Capitalization {
+    private String id;
+
+    public String getID() {
+        return id;
+    }
+}

--- a/feature-matcher-generator-e2e-test/src/test/java/ru/yandex/qatools/proc/test/CapitalizationTest.java
+++ b/feature-matcher-generator-e2e-test/src/test/java/ru/yandex/qatools/proc/test/CapitalizationTest.java
@@ -1,0 +1,20 @@
+package ru.yandex.qatools.proc.test;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Vladislav Bauer
+ */
+
+public class CapitalizationTest {
+
+    @Test
+    public void shouldFindMatcher() throws Exception {
+        assertThat(CapitalizationMatchers.class.getDeclaredMethod("withId", Matcher.class), notNullValue());
+    }
+
+}

--- a/feature-matcher-generator/src/test/java/ru/yandex/qatools/processors/matcher/gen/processing/MethodsCollectorTest.java
+++ b/feature-matcher-generator/src/test/java/ru/yandex/qatools/processors/matcher/gen/processing/MethodsCollectorTest.java
@@ -3,20 +3,21 @@ package ru.yandex.qatools.processors.matcher.gen.processing;
 import com.google.testing.compile.CompilationRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import ru.yandex.qatools.processors.matcher.gen.bean.ClassSpecDescription;
 import ru.yandex.qatools.processors.matcher.gen.testclasses.WithSomeFields;
+import ru.yandex.qatools.processors.matcher.gen.testclasses.WithoutGetter;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import java.util.LinkedList;
+import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static ru.yandex.qatools.processors.matcher.gen.processing.MethodsCollector.collectingMethods;
 
@@ -27,14 +28,12 @@ public class MethodsCollectorTest {
 
     @Rule
     public CompilationRule compilation = new CompilationRule();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldCollectFields() throws Exception {
-        TypeElement withFields = compilation.getElements().getTypeElement(WithSomeFields.class.getCanonicalName());
-        LinkedList<Element> fields = new LinkedList<>(compilation.getElements().getAllMembers(withFields).stream()
-                .filter(ofKind(ElementKind.FIELD))
-                .map(elem -> (Element) elem)
-                .collect(toList()));
+        LinkedList<Element> fields = findFields(WithSomeFields.class);
 
         ClassSpecDescription apply = collectingMethods().finisher().apply(fields);
 
@@ -42,11 +41,25 @@ public class MethodsCollectorTest {
         assertThat(apply.getSpec().methodSpecs, hasSize(fields.size() + 1));
         assertThat(
                 apply.getSpec().methodSpecs.stream().map(methodSpec -> methodSpec.name).collect(toList()),
-                hasItems("withValue", "withBytes", "withStr", "withInteger")
+                hasItems("withValue", "withBytes", "withStr", "withInteger", "withLower")
         );
     }
 
+    @Test
+    public void shouldThrowException_ifNoGetterPresent() throws Exception {
+        thrown.expect(NoSuchElementException.class);
+        thrown.expectMessage(allOf(containsString("WithoutGetter"), containsString("prop")));
 
+        collectingMethods().finisher().apply(findFields(WithoutGetter.class));
+    }
+    
+    private LinkedList<Element> findFields(final Class<?> withSomeFieldsClass) {
+        TypeElement withFields = compilation.getElements().getTypeElement(withSomeFieldsClass.getCanonicalName());
+        return new LinkedList<>(compilation.getElements().getAllMembers(withFields).stream()
+                .filter(ofKind(ElementKind.FIELD))
+                .map(elem -> (Element) elem)
+                .collect(toList()));
+    }
 
     public static Predicate<Element> ofKind(ElementKind kind) {
         return elem -> elem.getKind() == kind;

--- a/feature-matcher-generator/src/test/java/ru/yandex/qatools/processors/matcher/gen/testclasses/WithSomeFields.java
+++ b/feature-matcher-generator/src/test/java/ru/yandex/qatools/processors/matcher/gen/testclasses/WithSomeFields.java
@@ -8,4 +8,25 @@ public class WithSomeFields {
     byte[] bytes;
     String str;
     Integer integer;
+    String lower;
+
+    int getValue() {
+        return value;
+    }
+
+    byte[] getBytes() {
+        return bytes;
+    }
+
+    String getStr() {
+        return str;
+    }
+
+    Integer getInteger() {
+        return integer;
+    }
+
+    String getLOWER() {
+        return lower;
+    }
 }

--- a/feature-matcher-generator/src/test/java/ru/yandex/qatools/processors/matcher/gen/testclasses/WithoutGetter.java
+++ b/feature-matcher-generator/src/test/java/ru/yandex/qatools/processors/matcher/gen/testclasses/WithoutGetter.java
@@ -1,0 +1,5 @@
+package ru.yandex.qatools.processors.matcher.gen.testclasses;
+
+public class WithoutGetter {
+    private String prop;
+}


### PR DESCRIPTION
Getters and fields do not necessarily have the same capitalization. [This can e.g. be a problem when generating code using JAXB](https://stackoverflow.com/questions/31342360/jaxb-classes-from-schema-generates-getter-setter-method-in-uppercase).

The simplest solution I can think of would be to simply look for a matching getter case insensitively. This PR does that.